### PR TITLE
feat: add VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 500,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": null,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports.ruff": "always",
+        "source.fixAll.ruff": "always"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "python.analysis.typeCheckingMode": "basic",
+    "python.testing.pytestEnabled": true,
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "search.exclude": {
+        "**/__pycache__": true,
+        "**/.venv": true,
+        "**/.pytest_cache": true,
+        "**/uv.lock": true
+    }
+}


### PR DESCRIPTION
Configures VS Code for the FairBuddy development workflow:
- Auto-save after 500ms delay
- Ruff as Python formatter with format on save
- Auto organize imports and fix lint issues on save
- Basic type checking enabled
- Pytest test explorer integration
- File hygiene (trim trailing whitespace, ensure final newline)
- Search exclusions for __pycache__, .venv, .pytest_cache, uv.lock

Closes #5 