### PR TITLE
feat: add pre-commit hooks with Ruff and Commitizen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  # Standard file hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  # Ruff linter and formatter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Conventional commit message validation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.13.7
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,43 @@
 
 In order install necessary dependencies, run:
 
-```
+```bash
 ./boot.sh
+```
+
+## Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to enforce code quality before each commit.
+
+### Setup
+
+The hooks are installed automatically by `boot.sh`. To install them manually:
+
+```bash
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+### What Gets Checked
+
+On every commit the following hooks run automatically:
+
+- **Trailing whitespace** — removes trailing spaces
+- **End of file** — ensures files end with a newline
+- **YAML / TOML validation** — catches syntax errors in config files
+- **Merge conflict markers** — prevents committing unresolved conflicts
+- **Large files** — blocks accidentally committed large files
+- **Ruff lint** — checks Python code and auto-fixes issues
+- **Ruff format** — formats Python code
+- **Commitizen** — validates commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+### Commit Message Format
+
+Commit messages must follow Conventional Commits:
+
+```
+feat: add delete_item service
+fix: correct DynamoDB table name
+docs: update README with setup instructions
+chore: bump ruff to 0.15.1
 ```

--- a/boot.sh
+++ b/boot.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 tools=(
   awscli
   uv
+  pre-commit
 )
 
 ask() {
@@ -32,6 +33,11 @@ done
 if ask "Run aws configure now?"; then
   aws configure
 fi
+
+echo
+echo "Installing pre-commit hooks…"
+pre-commit install
+pre-commit install --hook-type commit-msg
 
 echo
 echo "Bootstrap finished."


### PR DESCRIPTION
Adds .pre-commit-config.yaml with:
- File hygiene hooks (whitespace, newlines, YAML/TOML validation)
- Ruff lint and format (matching CI checks)
- Commitizen conventional commit message validation

Updates boot.sh to install pre-commit and activate hooks. Updates README.md with pre-commit documentation.

Closes #2 